### PR TITLE
Minor docker fix and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ However, this does not install several key dependencies, namely `libmagic`, `ssd
 ### Dockerfile
 This dockerfile contains all the pertinent tools specific to data extraction. The main tools needed are `ssdeep`, `libmagic`, `tlsh`, and `detect-it-easy`. We have written some convenient scripts:
 ```bash
-wget https://github.com/LLNL/pEyeON/blob/main/docker-build.sh \
-     https://github.com/LLNL/pEyeON/blob/main/docker-run.sh \
-     https://github.com/LLNL/pEyeON/blob/main/eyeon.Dockerfile
+wget https://raw.githubusercontent.com/LLNL/pEyeON/refs/heads/main/docker-build.sh \
+     https://raw.githubusercontent.com/LLNL/pEyeON/refs/heads/main/docker-run.sh \
+     https://raw.githubusercontent.com/LLNL/pEyeON/refs/heads/main/eyeon.Dockerfile
 chmod +x docker-build.sh && ./docker-build.sh
 chmod +x docker-run.sh && ./docker-run.sh
 ```

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-container_name="eyeon"
+container_name="peyeon"
 
 # check to see if container already exists
 result=$(docker ps -a -q -f name=$container_name)
@@ -8,7 +8,7 @@ result=$(docker ps -a -q -f name=$container_name)
 if [ "$result" ]; then
     # Container already exists--launch the stopped container
     docker start "$container_name"
-    docker exec -it eyeon /bin/bash
+    docker exec -it $container_name /bin/bash
 else
     # Doesn't exist, creates a new container called eyeon
     docker run --name "$container_name" -p8888:8888 -p8501:8501 -it -v $(pwd):/workdir peyeon /bin/bash

--- a/eyeon.Dockerfile
+++ b/eyeon.Dockerfile
@@ -52,3 +52,5 @@ USER $OUN
 ENV PATH="/eye/bin:$PATH"
 
 ENV PATH=/home/$OUN/.local/bin:$PATH
+
+WORKDIR /workdir


### PR DESCRIPTION
This update fixes the links in the README.md for the docker file and scripts used to build a container. It also has minor changes to consistently use "peyeon" as the image and container name. And finally, the addition of "WORKDIR" to the Dockerfile which helps the user by defaulting to the WORKDIR as the starting shell location.