### PR TITLE
remove detect-it-easy

### DIFF
--- a/builds/install-ubuntu.sh
+++ b/builds/install-ubuntu.sh
@@ -20,11 +20,6 @@ cd /opt && git clone https://github.com/trendmicro/tlsh.git
 cd /opt/tlsh
 ./make.sh
 
-mkdir /opt/die && cd /opt/die
-wget https://github.com/horsicq/DIE-engine/releases/download/${DIE}/die_${DIE}_Ubuntu_24.04_amd64.deb
-apt-get install -y die_${DIE}_Ubuntu_24.04_amd64.deb
-apt-get clean
-
 cd $eyeon_dir
 # set up virtual environment
 python3 -m venv eye && source eye/bin/activate

--- a/builds/python3-slim-bookworm.Dockerfile
+++ b/builds/python3-slim-bookworm.Dockerfile
@@ -3,8 +3,6 @@ FROM python:3.13.1-slim-bookworm AS builder
 ARG USER_ID
 ARG OUN
 
-ENV DIE="3.10"
-
 RUN apt-get update \
     && apt-get install -y \
        git make wget unzip build-essential python3 python3-dev python3-venv \
@@ -24,23 +22,17 @@ RUN cd /opt && git clone https://github.com/trendmicro/tlsh.git \
 
 RUN python3 -m venv /eye && /eye/bin/pip install peyeon
 
-RUN mkdir -p /opt/die && cd /opt/die \
-    && wget https://github.com/horsicq/DIE-engine/releases/download/${DIE}/die_${DIE}_Ubuntu_24.04_amd64.deb
-
 #################################################
 
 FROM python:3.13.1-slim-bookworm
-COPY --from=builder /opt/die/ /opt/die
 COPY --from=builder /opt/tlsh/bin /opt/tlsh/bin
 COPY --from=builder /eye /eye
 ARG USER_ID
 ARG OUN
 
-ENV DIE="3.10"
-
 RUN apt-get update \
     && apt-get install -y \
-      libmagic1 ssdeep jq /opt/die/die_${DIE}_Ubuntu_24.04_amd64.deb \
+      libmagic1 ssdeep jq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We are not using the Detect-it-easy tool for any analysis at this time and removing it from our dockerfiles and install scripts. May eventually bring it back if we find some analysis we can do with its output. 