### PR TITLE
Centos build for build tests

### DIFF
--- a/.github/workflows/containerbuild.yml
+++ b/.github/workflows/containerbuild.yml
@@ -25,3 +25,22 @@ jobs:
       - name: Run Test Command
         run: |
             docker run --rm peyeon:buildx sh -c "eyeon --help"
+
+  podman-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Podman
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+
+      - name: Build Podman Image
+        run: |
+            podman build --build-arg base_image=quay.io/centos/centos:9 -f builds/ubi8.Dockerfile -t peyeon:podman .
+    
+      - name: Run Test Command
+        run: |
+            podman run --rm peyeon:podman sh -c "eyeon --help"

--- a/builds/ubi8.Dockerfile
+++ b/builds/ubi8.Dockerfile
@@ -1,4 +1,5 @@
-from ubi8 as builder
+arg base_image=ubi8
+from ${base_image} as builder
 
 run yum update -y && yum groupinstall -y 'Development Tools' \
     && yum install -y python3.12 git make wget unzip python3.12-devel cmake file
@@ -15,7 +16,7 @@ run cd /opt \
 
 run python3.12 -m venv /eye && /eye/bin/pip install --upgrade pip && /eye/bin/pip install peyeon  
 
-from ubi8
+from ${base_image}
 copy --from=builder /opt/tlsh/bin /opt/tlsh/bin
 copy --from=builder /eye /eye
 copy --from=builder /usr/local/bin/ssdeep /usr/local/bin/ssdeep

--- a/builds/ubi8.Dockerfile
+++ b/builds/ubi8.Dockerfile
@@ -1,3 +1,4 @@
+#base_image needed for build tests on github. no need to adjust for end-user
 arg base_image=ubi8
 from ${base_image} as builder
 


### PR DESCRIPTION
Leveraging centos in place of rhel for github testing. Rhel requires an active subscription manager in order to use package repos and centos appears to be a good alternative 