### PR TITLE
add builds folder to dockerfile path

### DIFF
--- a/builds/docker-build.sh
+++ b/builds/docker-build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build --build-arg "OUN=$(whoami)" --build-arg "USER_ID=$(id -u $OUN)" -t peyeon -f python3-slim-bookworm.Dockerfile .
+docker build --build-arg "OUN=$(whoami)" --build-arg "USER_ID=$(id -u $OUN)" -t peyeon -f builds/python3-slim-bookworm.Dockerfile .


### PR DESCRIPTION
Need to add `builds` dir in the path for it to find the dockerfile in the `docker-build.sh` script. 